### PR TITLE
Created a command for khlinks and lets dev team members select pr members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .vscode
 git
 __pycache__
+cogs/__pycache__
 *.pyc
 *.log

--- a/bot.py
+++ b/bot.py
@@ -6,10 +6,10 @@ from dotenv import load_dotenv
 from discord.ext import commands
 import builtins
 
-intents = discord.Intents.default()
-intents.members = True
+# intents = discord.Intents.default()
+# intents.members = True
 
-bot = commands.Bot(command_prefix = '!', activity = discord.Game('with the discord API!'), intents=intents)
+bot = commands.Bot(command_prefix = '!', activity = discord.Game('with the discord API!'))
 bot.remove_command('help')
 builtins.bot = bot
 

--- a/cogs/devselect.py
+++ b/cogs/devselect.py
@@ -1,0 +1,28 @@
+import discord
+from discord.ext import commands
+import random
+class Devselect(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(aliases=["pr-reviewers", "pr-reviewer-select", "pr", "pr-review"])
+    @commands.has_role("Dev Team")
+    async def devselect(self, ctx, count, *names):
+        if(len(names) > count):
+            await ctx.send(
+                f"{ctx.author.mention}" + " please only use " + str(count) + " names for pr reviewers!"
+            )
+
+        elif(len(names) < count):
+               await ctx.send(
+                f"{ctx.author.mention}" + " please only use " + str(count) + " names for pr reviewers!"
+            )
+
+        pr_reviewers = ", ".join(random.choices(names, k = int(count)))
+        await ctx.send(
+                        f"{ctx.author.mention}"
+        )
+        await ctx.send("PR reviewers selected from list are: " + pr_reviewers)
+
+def setup(bot):
+    bot.add_cog(Devselect(bot))

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -26,6 +26,7 @@ class Help(commands.Cog):
         embed.add_field(name='whois', value='Displays the specified user\'s info. If no user is tagged, displays the author\'s info.')
         embed.add_field(name='pfp', value='Displays the specified user\'s profile picture.')
         embed.add_field(name='server / serverstats / stats / info', value='Displays server info.', inline=False)
+        embed.add_field(name='links / membership-dues / feedback / fees / ops', value = 'Displays various important KnightHacks links')
         embed.add_field(name='weather', value='Displays specified city\'s current weather.', inline=False)
         embed.add_field(name='cat', value='Displays a random cat.')
         embed.add_field(name='dog', value='Displays a random dog.')

--- a/cogs/links.py
+++ b/cogs/links.py
@@ -1,0 +1,24 @@
+import discord
+from discord.ext import commands
+class Links(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(aliases=["links", "membership-dues", "feedback", "fees", "ops"])
+    async def khlinks(self, ctx):
+        links = ("[Find current events happening this week!](https://knighthacks.org/linktree)" +
+            "\n\n[Pay your dues](https://knighthacks.org/dues)\n\n" +
+            "[Give feedback on a specific workshop](https://knighthacks.org/feedback)\n\n" +
+            "[Sign up to be a Knight Hacks club member](https://knighthacks.org/membership)\n\n" + 
+            "[Come to our ops meeting](https://knighthacks.org/ops)")
+
+        await ctx.send(
+                        f"{ctx.author.mention}"
+        )
+        embed = discord.Embed(color=0x7ce4f7, timestamp=ctx.message.created_at)
+        embed.add_field(name="KnightHacks links", value=links)
+        embed.set_thumbnail(url = "https://github.com/lienne/ModiBot/blob/master/cogs/img/headphonesdog.png?raw=true")
+        await ctx.send(embed=embed)
+
+def setup(bot):
+    bot.add_cog(Links(bot))


### PR DESCRIPTION
These commands allow shortcuts for important knighthacks link such as ops, dues, membership link, as well as allowing a user with the Dev Team role to select people for PR-review. 

I commented out discord intents, as the version of discord.py in requirements.txt does not seem to have them?